### PR TITLE
Added handling of 'HTTP/1.1 100 continue' responses

### DIFF
--- a/src/HTTPQueryHandler.php
+++ b/src/HTTPQueryHandler.php
@@ -72,6 +72,7 @@ class HTTPQueryHandler {
 		curl_setopt($conn, CURLOPT_POST, 1);
 		curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
 		curl_setopt($conn, CURLOPT_POSTFIELDS, $body);
+		curl_setopt($conn, CURLOPT_HTTPHEADER, array('Expect:'));
 
 		$response = curl_exec($conn);
 		list($headers, $body) = explode("\r\n\r\n", $response, 2);


### PR DESCRIPTION
The signature checking within the client was throwing an exception upon receiving the 'HTTP/1.1 100 continue' response from the server. This was happening because the server would not include the 'X-Signature*" headers when sending these responses.

More info: https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.2.3
